### PR TITLE
memory_manager: Do not allow 0 to be a valid GPUVAddr.

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -9,6 +9,13 @@
 
 namespace Tegra {
 
+MemoryManager::MemoryManager() {
+    // Mark the first page as reserved, so that 0 is not a valid GPUVAddr. Otherwise, games might
+    // try to use 0 as a valid address, which is also used to mean nullptr. This fixes a bug with
+    // Undertale using 0 for a render target.
+    PageSlot(0) = static_cast<u64>(PageStatus::Reserved);
+}
+
 GPUVAddr MemoryManager::AllocateSpace(u64 size, u64 align) {
     const std::optional<GPUVAddr> gpu_addr{FindFreeBlock(0, size, align, PageStatus::Unmapped)};
 

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -18,7 +18,7 @@ using GPUVAddr = u64;
 
 class MemoryManager final {
 public:
-    MemoryManager() = default;
+    MemoryManager();
 
     GPUVAddr AllocateSpace(u64 size, u64 align);
     GPUVAddr AllocateSpace(GPUVAddr gpu_addr, u64 size, u64 align);
@@ -37,6 +37,7 @@ private:
     enum class PageStatus : u64 {
         Unmapped = 0xFFFFFFFFFFFFFFFFULL,
         Allocated = 0xFFFFFFFFFFFFFFFEULL,
+        Reserved = 0xFFFFFFFFFFFFFFFDULL,
     };
 
     std::optional<GPUVAddr> FindFreeBlock(GPUVAddr region_start, u64 size, u64 align,


### PR DESCRIPTION
- Fixes a bug with Undertale using 0 for a render target.